### PR TITLE
Hungarian alphabet support

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -72,6 +72,25 @@ up the punctuations a little. I think that mirroring is easy to learn.
 
 ### English Prose Layer
 
+,  w  f  p  b  j  l  u  y  q
+a  r  s  t  g  m  n  e  i  o
+.  '  c  d  v  k  h  /  x  z
+
+experiments:
+
+b l x g v j p ' u ,
+n s r t k q h e i o
+c w z m f y d / . a
+
+b c l w q  k p u . a
+n s r t v  y h e i o
+x g j m z  f d ' , /
+
+b a l m z  k p u c .
+n o r t v  y h e s i
+x / j w q  f d ' g ,
+
+
 ### Acute Prose Layer
 
 ### Double Acute Prose Layer

--- a/README.MD
+++ b/README.MD
@@ -1,22 +1,86 @@
-Design
+The 6yozu keyboard layout
+===
 
-- Typing is preferred over other actions
-  - Example: When Shift and Ctrl fights for the same location Shift
-    wins, because it is needed to type upper case letters.
+The 6yozu keyboard layout is based on the Miryoku layout. The core of
+the layout is the Colmak-DOX language layout, which lets you type
+prose in English and Hungarian.
 
-- Every button should have an equivalent to the US ANSI layout
+General Design Goals
+---
 
-Differences to Miryoku
+- Every button on the US ANSI layout should have an equivalent on the
+  6yozu layout.
 
-- Right Alt is not used
-- On the base layer no home row mods
-  - They were triggered involuntarily sometimes
-- On Media and Nav layer one shot mods are used, which can be used
-  with the base layer buttons
-- The Media and Nav layer must be accessed by a single function key.
-  One shot mods are not activated when typing fast(rolling) and when
-  they are accessed via layer tap(which is a dual function key).
-- The delete key is only on the Nav layer
+- There is no Right Alt(Alt Gr) key on the layout.
+
+- The Colmak-DOX layers comprise letters, accents, punctuations, and
+  modifiers for writing prose only.
+
+- There are no home row mods on the base layers, the tap-hold
+  behaviour is not typing friendly, especially when you are rolling
+  from key to key.
+
+- One shot modifiers are on the media and function layer.
+
+- The buttons that switch to the Media and the Nav layer are on a
+  dedicated single function thumb key. Dual function keys do not
+  activate one shot modifiers on the Nav and Media layer when typing
+  fast (rolling).
+
+- The delete key is only on the nav layer.
+
 - The ESC key is on the function layer. It remains in its original
-  location and APP key is moved to the outer thumb key, and TAB is
-  removed from the layer.
+  location. The APP key is on to the outer thumb key. The TAB key is
+  not on the layer.
+
+Colemak-DOX
+---
+
+I have created the Colemak-DOX layout to support accent
+layers. Colmak-DOX enables typing Hungarian texts besides English.
+
+Design goals:
+
+- Create three distinct layers for the Hungarian accents.
+
+- Keep as much similarity to Colemak-DH as possible.
+
+- Keep the base layer English oriented.
+
+- Do not change thumb keys.
+
+- Optimize for typing prose over other activities.
+
+- Avoid SFBs when typing accents.
+
+Rational:
+---
+
+English oriented base layer means that one can type English texts
+using the base layer alone.
+
+- Thumb keys rarely contain letters, they are mostly modifiers or
+  layer switching keys. If we do not change the thumb keys, then we
+  can keep the similarity to widespread layouts like Miryoku or
+  Seniply.
+
+Implementation
+---
+
+I have mirrored the Q, Z and X keys on the Colemak-DH layout and mixed
+up the punctuations a little. I think that mirroring is easy to learn.
+
+### English Prose Layer
+
+### Acute Prose Layer
+
+### Double Acute Prose Layer
+
+### Diaresis Prose Layer
+
+Tap Hold and typing
+---
+
+Tap-hold buttons work the best if you can use them as if they are in
+the same column. They become SFBs no matter where they are on the
+keyboard.

--- a/config/waterfowl.keymap
+++ b/config/waterfowl.keymap
@@ -11,6 +11,19 @@
 #include <dt-bindings/zmk/outputs.h>
 #include <dt-bindings/zmk/ext_power.h>
 
+// Postfix naming convention
+// ---
+// First letter:
+//   w -> windows
+//   l -> linux
+//   m -> mac
+// 2nd and 3rd letter:
+//   en -> US International
+//   hu -> Hungarian
+//
+// dacute -> double acute
+// cap -> capital
+
 / {
     behaviors {
       skq: sticky_key_quick_release {
@@ -22,42 +35,341 @@
         quick-release;
         ignore-modifiers;
       };
+
+      o_acute_wen: o_acute_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "O_ACUTE_WITH_SHIFT";
+        #binding-cells = <0>;
+        bindings = <&m_o_acute_wen>, <&m_cap_o_acute_wen>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+      
+      e_acute_wen: e_acute_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "E_ACUTE_WITH_SHIFT";
+        #binding-cells = <0>;
+        bindings = <&m_e_acute_wen>, <&m_cap_e_acute_wen>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
+      a_acute_wen: a_acute_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "A_ACUTE_WITH_SHIFT";
+        #binding-cells = <0>;
+        bindings = <&m_a_acute_wen>, <&m_cap_a_acute_wen>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
+      u_acute_wen: u_acute_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "U_ACUTE_WITH_SHIFT";
+        #binding-cells = <0>;
+        bindings = <&m_u_acute_wen>, <&m_cap_u_acute_wen>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
+      i_acute_wen: i_acute_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "I_ACUTE_WITH_SHIFT";
+        #binding-cells = <0>;
+        bindings = <&m_i_acute_wen>, <&m_cap_i_acute_wen>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
+      o_dacute_wen: o_dacute_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "O_DACUTE_WITH_SHIFT";
+        #binding-cells = <0>;
+        bindings = <&m_o_dacute_wen>, <&m_cap_o_dacute_wen>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
+      u_dacute_wen: u_dacute_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "U_DACUTE_WITH_SHIFT";
+        #binding-cells = <0>;
+        bindings = <&m_u_dacute_wen>, <&m_cap_u_dacute_wen>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
+      o_diaresis_wen: o_diaresis_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "O_DIARESIS_WITH_SHIFT";
+        #binding-cells = <0>;
+        bindings = <&m_o_diaresis_wen>, <&m_cap_o_diaresis_wen>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
+      u_diaresis_wen: u_diaresis_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "U_DIARESIS_WITH_SHIFT";
+        #binding-cells = <0>;
+        bindings = <&m_u_diaresis_wen>, <&m_cap_u_diaresis_wen>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
     };
 
-/* macros {
-        ZMK_MACRO(mq,
-            wait-ms = <30>;
-            tap-ms = <40>;
-            bindings = <&kp Q &to 0>;
+ macros {
+ // wait-ms and tap-ms value
+ // ---
+ //
+ // Executing an accented macro should not take longer than tapping a dedicated
+ // key at maximum speed(300 WPM).
+ //
+ // 38 WPM -> 188 CPM, so 300 WPM -> (* 188 (/ 300 38)) = 1316 CPM =
+ // (/ 1316 60) CPS = 21 CPS
+ //
+ // Hitting keys close to 50 ms / keypress is humanly possible.
+ //
+ // Unicode Sequences
+ // ---
+ //
+ // Emacs uses the alt-num combination as a prefix argument, so unicode
+ // sequences do not work in emacs
+ //
+ // Num lock state interferes with Unicode Sequences. You must have a num lock
+ // key to make unicode sequences work.
+ //
+ // Unicode Sequences do not handle shift states automatically for capital
+ // letters
+
+        ZMK_MACRO(m_e_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N3 &kp KP_N0>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
         )
 
-        ZMK_MACRO(my_macro,
-            wait-ms = <30>;
-            tap-ms = <40>;
-            bindings = <&kp Z &kp M &kp K>;
+        ZMK_MACRO(m_cap_e_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N4 &kp KP_N4>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
         )
-    };
 
-    behaviors {
-        td0: tap_dance_0 {
-            compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_0";
-            #binding-cells = <0>;
-            tapping-term-ms = <200>;
-            bindings = <&kp N1>, <&kp N2>, <&kp N3>, <&my_macro>;
-        };
+        ZMK_MACRO(m_a_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N0>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_cap_a_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N0 &kp KP_N1 &kp KP_N9 &kp KP_N3>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+        
+        ZMK_MACRO(m_o_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N2>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_cap_o_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N0 &kp KP_N2 &kp KP_N1 &kp KP_N1>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_i_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N1>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_cap_i_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N0 &kp KP_N2 &kp KP_N0 &kp KP_N5>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_u_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N3>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_cap_u_acute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N0 &kp KP_N2 &kp KP_N1 &kp KP_N8>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_c_acute_wen,
+            wait-ms = <25>;
+            tap-ms = <25>;
+            bindings
+                = <&macro_tap     &kp C>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_o_dacute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N0 &kp KP_N3 &kp KP_N3 &kp KP_N7>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_cap_o_dacute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N0 &kp KP_N3 &kp KP_N3 &kp KP_N6>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_u_dacute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N0 &kp KP_N3 &kp KP_N6 &kp KP_N9>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_cap_u_dacute_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N0 &kp KP_N3 &kp KP_N6 &kp KP_N8>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_y_dacute_wen,
+            wait-ms = <25>;
+            tap-ms = <25>;
+            bindings
+                = <&macro_tap     &kp Y>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_o_diaresis_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N4 &kp KP_N8>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_cap_o_diaresis_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N5 &kp KP_N3>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_u_diaresis_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N2 &kp KP_N9>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_cap_u_diaresis_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N5 &kp KP_N4>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
+        ZMK_MACRO(m_q_diaresis_wen,
+            wait-ms = <25>;
+            tap-ms = <25>;
+            bindings
+                = <&macro_tap     &kp Q>
+                , <&macro_tap     &to 0>
+                ;
+        )
+
     };
-  */  
 
     keymap {
         compatible = "zmk,keymap";
 
-        default_layer {
+        base_wen_layer {
 // 0: COLEMAK-DH
             bindings = <
-    &kp Q   &kp W  &kp F        &kp P      &kp B           &kp J   &kp L      &kp U       &kp Y    &kp SQT
+    &to 9   &kp W  &kp F        &kp P      &kp B           &kp J   &kp L      &kp U       &to 8    &kp SQT
     &kp A   &kp R  &kp S        &kp T      &kp G           &kp M   &kp N      &kp E       &kp I    &kp O
-    &kp Z   &kp X  &kp C        &kp D      &kp V           &kp K   &kp H      &kp COMMA   &kp DOT  &kp SLASH
+    &kp Z   &kp X  &to 7        &kp D      &kp V           &kp K   &kp H      &kp COMMA   &kp DOT  &kp SLASH
     &kp N1  &mo 6  &lt 1 SPACE  &lt 5 TAB  &kp N2          &kp N3  &lt 3 RET  &lt 2 BSPC  &mo 4    &kp N4
             >;
 
@@ -139,16 +451,41 @@
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
         };
 
-        accent_layer {
-// 7: Accent
+        acute_wen_layer {
+// 7: Acute Layer
             bindings = <
-    &mq         &kp W       &kp F        &kp P        &kp B           &kp J   &kp L        &kp U        &kp Y         &kp SQT
-    &mt LGUI A  &mt LALT R  &mt LCTRL S  &mt LSHFT T  &kp G           &kp M   &mt LSHFT N  &mt LCTRL E  &mt LALT I    &mt LGUI O
-    &kp Z       &mt RALT X  &kp C        &kp D        &kp V           &kp K   &kp H        &kp COMMA    &mt RALT DOT  &kp SLASH
-    &kp N1      &lt 6 ESC   &lt 1 SPACE  &lt 5 TAB    &kp N2          &kp N3  &lt 3 RET    &lt 2 BSPC   &lt 4 DEL     &kp N4
+    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_acute_wen    &to 0         &to 0
+    &a_acute_wen  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &e_acute_wen    &i_acute_wen  &o_acute_wen
+    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &m_c_acute_wen  &to 0         &to 0
+    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &to 0         &to 0
           >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
         };
+
+        dacute_wen_layer {
+// 8: Double Acute Layer
+            bindings = <
+    &to 0  &m_y_dacute_wen  &to 0  &to 0  &to 0           &to 0  &to 0  &u_dacute_wen  &to 0  &to 0
+    &to 0  &to 0            &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &o_dacute_wen
+    &to 0  &to 0            &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &to 0
+    &to 0  &to 0            &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &to 0
+          >;
+
+            sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
+        };
+
+        diaresis_layer {
+// 9: Diaresis Layer
+            bindings = <
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_diaresis_wen  &to 0  &m_q_diaresis_wen
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &o_diaresis_wen
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &to 0
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &to 0
+          >;
+
+            sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
+        };
+
     };
 };

--- a/config/waterfowl.keymap
+++ b/config/waterfowl.keymap
@@ -30,11 +30,11 @@
 #define WEN_BASE 0
 #define NAV      1
 #define WEN_NUM  2
-#define WEN_SYM  3
-#define FUNC     4
-#define MEDIA    5
+#define FUNC     3
+#define MEDIA    4
 // Acute
-#define WEN_AL   6
+#define WEN_AL   5
+#define WEN_AL2  6
 // Double acute
 #define WEN_DAL  7
 // Diaresis
@@ -88,7 +88,7 @@
         compatible = "zmk,behavior-mod-morph";
         label = "A_ACUTE_WITH_SHIFT";
         #binding-cells = <0>;
-        bindings = <&m_a_acute_wen>, <&m_cap_a_acute_wen>;
+        bindings = <&m_a_acute2_wen>, <&m_cap_a_acute2_wen>;
         mods = <(MOD_RSFT|MOD_LSFT)>;
       };
 
@@ -188,28 +188,6 @@
                 ;
         )
 
-        ZMK_MACRO(m_a_acute_wen,
-            wait-ms = <13>;
-            tap-ms = <13>;
-            bindings
-                = <&macro_press   &kp LALT>
-                , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N0>
-                , <&macro_release &kp LALT>
-                , <&macro_tap     &to WEN_BASE>
-                ;
-        )
-
-        ZMK_MACRO(m_cap_a_acute_wen,
-            wait-ms = <13>;
-            tap-ms = <13>;
-            bindings
-                = <&macro_press   &kp LALT>
-                , <&macro_tap     &kp KP_N0 &kp KP_N1 &kp KP_N9 &kp KP_N3>
-                , <&macro_release &kp LALT>
-                , <&macro_tap     &to WEN_BASE>
-                ;
-        )
-        
         ZMK_MACRO(m_o_acute_wen,
             wait-ms = <13>;
             tap-ms = <13>;
@@ -281,6 +259,37 @@
             tap-ms = <25>;
             bindings
                 = <&macro_tap     &sqt_fslh_wen>
+                , <&macro_tap     &to WEN_BASE>
+                ;
+        )
+        
+        ZMK_MACRO(m_a_acute2_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N0>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to WEN_BASE>
+                ;
+        )
+
+        ZMK_MACRO(m_cap_a_acute2_wen,
+            wait-ms = <13>;
+            tap-ms = <13>;
+            bindings
+                = <&macro_press   &kp LALT>
+                , <&macro_tap     &kp KP_N0 &kp KP_N1 &kp KP_N9 &kp KP_N3>
+                , <&macro_release &kp LALT>
+                , <&macro_tap     &to WEN_BASE>
+                ;
+        )
+
+        ZMK_MACRO(m_dqt_qmark_acute2_wen,
+            wait-ms = <25>;
+            tap-ms = <25>;
+            bindings
+                = <&macro_tap     &dqt_qmark_wen>
                 , <&macro_tap     &to WEN_BASE>
                 ;
         )
@@ -397,11 +406,11 @@
         compatible = "zmk,keymap";
 
         base_wen_layer {
-// 0: COLEMAK-DH
+// COLEMAK-DH
             bindings = <
     &to WEN_DAL  &kp W       &kp F          &kp P    &kp B           &kp J   &kp L        &kp U                 &kp Y     &kp Q
     &kp A        &kp R       &kp S          &kp T    &kp G           &kp M   &kp N        &kp E                 &kp I     &kp O
-    &to WEN_DL   &to WEN_AL  &kp C          &kp D    &kp V           &kp K   &kp H        &dqt_qmark_wen        &kp X     &kp Z
+    &to WEN_DL   &to WEN_AL  &kp C          &kp D    &kp V           &kp K   &kp H        &to WEN_AL2           &kp X     &kp Z
     &kp N1       &mo MEDIA   &lt NAV SPACE  &kp TAB  &kp N2          &kp N3  &skq LSHFT   &lt WEN_NUM LC(BSPC)  &mo FUNC  &kp N4
             >;
 
@@ -409,7 +418,7 @@
         };
 
         navigation_layer {
-/* 1: NAV
+/* NAV
  * Bootloader does not work on the peripherial side of the split keyboard only on the central side.
  * The reset button can be used to go into bootloader mode instead.
  */
@@ -424,7 +433,7 @@
         };
 
         number_layer {
-// 2: NUM, KP_DOT would be better here instad of DOT, but num lock state interferes with KP_DOT.
+// NUM, KP_DOT would be better here instad of DOT, but num lock state interferes with KP_DOT.
             bindings = <
     &kp LBKT   &kp N7   &kp N8  &kp N9     &kp RBKT           &none   &none      &none      &none     &none
     &kp SEMI   &kp N4   &kp N5  &kp N6     &kp EQUAL          &none   &kp LSHFT  &kp LCTRL  &kp LALT  &kp LGUI
@@ -435,20 +444,8 @@
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
         };
 
-        symbol_layer {
-// 3: SYM, NUM + SHIFT can be used instead
-            bindings = <
-    &kp LBRC   &kp AMPS  &kp ASTRK  &kp LPAR   &kp RBRC          &none   &none      &none      &none     &none
-    &kp COLON  &kp DLLR  &kp PRCNT  &kp CARET  &kp PLUS          &none   &kp LSHFT  &kp LCTRL  &kp LALT  &kp LGUI
-    &kp TILDE  &kp EXCL  &kp AT     &kp HASH   &kp PIPE          &none   &none      &none      &none     &none
-    &kp N1     &kp LPAR  &kp RPAR   &kp UNDER  &kp N2            &kp N3  &none      &none      &none     &kp N4
-            >;
-
-            sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
-        };
-
         function_layer {
-// 4: FUNC
+// FUNC
             bindings = <
     &kp F12  &kp F7   &kp F8     &kp F9     &kp PSCRN                &none   &none       &none       &none      &none
     &kp F11  &kp F4   &kp F5     &kp F6     &kp SLCK                 &none   &skq LSHFT  &skq LCTRL  &skq LALT  &skq LGUI
@@ -460,7 +457,7 @@
         };
 
         media_layer {
-// 6: Media
+// MEDIA
             bindings = <
     &none      &none      &none       &none       &none           &rgb_ug RGB_TOG  &rgb_ug RGB_EFF  &rgb_ug RGB_HUI  &rgb_ug RGB_SAI  &rgb_ug RGB_BRI
     &skq LGUI  &skq LALT  &skq LCTRL  &skq LSHFT  &none           &kp EP_TOG       &kp C_PREV       &kp C_VOL_DN     &kp C_VOL_UP     &kp C_NEXT
@@ -472,10 +469,10 @@
         };
 
         acute_wen_layer {
-// 7: Acute Layer
+// ACUTE LAYER
             bindings = <
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_acute_wen  &to WEN_BASE           &to WEN_BASE
-    &a_acute_wen  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &e_acute_wen  &i_acute_wen           &o_acute_wen
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &e_acute_wen  &i_acute_wen           &o_acute_wen
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &m_sqt_fslh_acute_wen  &to WEN_BASE
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE
           >;
@@ -483,8 +480,20 @@
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
         };
 
+        acute2_wen_layer {
+// ACUTE LAYER 2
+            bindings = <
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE             &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE
+    &a_acute_wen  &to WEN_BASE  &to WEN_BASE  &m_dqt_qmark_acute2_wen  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE             &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE             &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE
+          >;
+
+            sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
+        };
+
         dacute_wen_layer {
-// 8: Double Acute Layer
+// DOUBLE ACUTE LAYER
             bindings = <
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_dacute_wen  &to WEN_BASE  &m_comma_dacute_wen 
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE   &to WEN_BASE  &o_dacute_wen
@@ -496,7 +505,7 @@
         };
 
         diaresis_layer {
-// 9: Diaresis Layer
+// DIARESIS LAYER
             bindings = <
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_diaresis_wen  &to WEN_BASE  &to WEN_BASE
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE     &to WEN_BASE  &o_diaresis_wen

--- a/config/waterfowl.keymap
+++ b/config/waterfowl.keymap
@@ -70,10 +70,10 @@
  * The reset button can be used to go into bootloader mode instead.
  */
             bindings = <
-    &none     &none     &none      &none      &none               &kp K_AGAIN  &kp K_PASTE  &kp K_COPY  &kp K_CUT  &kp K_UNDO
-    &kp LGUI  &kp LALT  &kp LCTRL  &kp LSHFT  &caps_word          &kp CAPS     &kp LEFT     &kp DOWN    &kp UP     &kp RIGHT
-    &none     &none     &none      &none      &none               &kp INS      &kp HOME     &kp PG_DN   &kp PG_UP  &kp END
-    &kp N1    &none     &none      &none      &kp N2              &kp N3       &kp RET      &kp BSPC    &kp DEL    &kp N4
+    &none     &none     &none      &none      &kp KP_NUMLOCK          &kp K_AGAIN  &kp K_PASTE  &kp K_COPY  &kp K_CUT  &kp K_UNDO
+    &kp LGUI  &kp LALT  &kp LCTRL  &kp LSHFT  &caps_word              &kp CAPS     &kp LEFT     &kp DOWN    &kp UP     &kp RIGHT
+    &none     &none     &none      &none      &kp SCROLLLOCK          &kp INS      &kp HOME     &kp PG_DN   &kp PG_UP  &kp END
+    &kp N1    &none     &none      &none      &kp N2                  &kp N3       &kp RET      &kp BSPC    &kp DEL    &kp N4
             >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;

--- a/config/waterfowl.keymap
+++ b/config/waterfowl.keymap
@@ -244,11 +244,11 @@
                 ;
         )
 
-        ZMK_MACRO(m_c_acute_wen,
+        ZMK_MACRO(m_dot_acute_wen,
             wait-ms = <25>;
             tap-ms = <25>;
             bindings
-                = <&macro_tap     &kp C>
+                = <&macro_tap     &kp DOT>
                 , <&macro_tap     &to 0>
                 ;
         )
@@ -297,11 +297,11 @@
                 ;
         )
 
-        ZMK_MACRO(m_y_dacute_wen,
+        ZMK_MACRO(m_slash_dacute_wen,
             wait-ms = <25>;
             tap-ms = <25>;
             bindings
-                = <&macro_tap     &kp Y>
+                = <&macro_tap     &kp SLASH>
                 , <&macro_tap     &to 0>
                 ;
         )
@@ -350,11 +350,11 @@
                 ;
         )
 
-        ZMK_MACRO(m_q_diaresis_wen,
+        ZMK_MACRO(m_sqt_diaresis_wen,
             wait-ms = <25>;
             tap-ms = <25>;
             bindings
-                = <&macro_tap     &kp Q>
+                = <&macro_tap     &kp SQT>
                 , <&macro_tap     &to 0>
                 ;
         )
@@ -367,9 +367,9 @@
         base_wen_layer {
 // 0: COLEMAK-DH
             bindings = <
-    &to 9   &kp W  &kp F        &kp P      &kp B           &kp J   &kp L      &kp U       &to 8    &kp SQT
+    &to 9   &kp W  &kp F        &kp P      &kp B           &kp J   &kp L      &kp U       &kp Y    &kp Q
     &kp A   &kp R  &kp S        &kp T      &kp G           &kp M   &kp N      &kp E       &kp I    &kp O
-    &kp Z   &kp X  &to 7        &kp D      &kp V           &kp K   &kp H      &kp COMMA   &kp DOT  &kp SLASH
+    &to 8   &to 7  &kp C        &kp D      &kp V           &kp K   &kp H      &kp COMMA   &kp X    &kp Z
     &kp N1  &mo 6  &lt 1 SPACE  &lt 5 TAB  &kp N2          &kp N3  &lt 3 RET  &lt 2 BSPC  &mo 4    &kp N4
             >;
 
@@ -454,10 +454,10 @@
         acute_wen_layer {
 // 7: Acute Layer
             bindings = <
-    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_acute_wen    &to 0         &to 0
-    &a_acute_wen  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &e_acute_wen    &i_acute_wen  &o_acute_wen
-    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &m_c_acute_wen  &to 0         &to 0
-    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &to 0         &to 0
+    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_acute_wen    &to 0             &to 0
+    &a_acute_wen  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &e_acute_wen    &i_acute_wen      &o_acute_wen
+    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &m_dot_acute_wen  &to 0
+    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &to 0             &to 0
           >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
@@ -466,10 +466,10 @@
         dacute_wen_layer {
 // 8: Double Acute Layer
             bindings = <
-    &to 0  &m_y_dacute_wen  &to 0  &to 0  &to 0           &to 0  &to 0  &u_dacute_wen  &to 0  &to 0
-    &to 0  &to 0            &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &o_dacute_wen
-    &to 0  &to 0            &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &to 0
-    &to 0  &to 0            &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &to 0
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_dacute_wen  &to 0  &to 0
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &o_dacute_wen
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &m_slash_dacute_wen
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &to 0
           >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
@@ -478,7 +478,7 @@
         diaresis_layer {
 // 9: Diaresis Layer
             bindings = <
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_diaresis_wen  &to 0  &m_q_diaresis_wen
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_diaresis_wen  &to 0  &m_sqt_diaresis_wen
     &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &o_diaresis_wen
     &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &to 0
     &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &to 0

--- a/config/waterfowl.keymap
+++ b/config/waterfowl.keymap
@@ -11,7 +11,7 @@
 #include <dt-bindings/zmk/outputs.h>
 #include <dt-bindings/zmk/ext_power.h>
 
-// Postfix naming convention
+// Naming convention
 // ---
 // First letter:
 //   w -> windows
@@ -23,6 +23,22 @@
 //
 // dacute -> double acute
 // cap -> capital
+
+// LAYERS FOR WIN-ENGLISH-QUERTY HOST (WEN)
+//
+// Colemak-DOX
+#define WEN_BASE 0
+#define NAV      1
+#define WEN_NUM  2
+#define WEN_SYM  3
+#define FUNC     4
+#define MEDIA    5
+// Acute
+#define WEN_AL   6
+// Double acute
+#define WEN_DAL  7
+// Diaresis
+#define WEN_DL   8
 
 / {
     behaviors {
@@ -141,7 +157,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N3 &kp KP_N0>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -152,7 +168,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N4 &kp KP_N4>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -163,7 +179,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N0>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -174,7 +190,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N0 &kp KP_N1 &kp KP_N9 &kp KP_N3>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
         
@@ -185,7 +201,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N2>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -196,7 +212,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N0 &kp KP_N2 &kp KP_N1 &kp KP_N1>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -207,7 +223,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N1>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -218,7 +234,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N0 &kp KP_N2 &kp KP_N0 &kp KP_N5>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -229,7 +245,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N6 &kp KP_N3>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -240,7 +256,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N0 &kp KP_N2 &kp KP_N1 &kp KP_N8>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -249,7 +265,7 @@
             tap-ms = <25>;
             bindings
                 = <&macro_tap     &kp DOT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -260,7 +276,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N0 &kp KP_N3 &kp KP_N3 &kp KP_N7>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -271,7 +287,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N0 &kp KP_N3 &kp KP_N3 &kp KP_N6>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -282,7 +298,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N0 &kp KP_N3 &kp KP_N6 &kp KP_N9>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -293,7 +309,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N0 &kp KP_N3 &kp KP_N6 &kp KP_N8>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -302,7 +318,7 @@
             tap-ms = <25>;
             bindings
                 = <&macro_tap     &kp COMMA>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -313,7 +329,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N4 &kp KP_N8>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -324,7 +340,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N5 &kp KP_N3>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -335,7 +351,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N2 &kp KP_N9>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -346,7 +362,7 @@
                 = <&macro_press   &kp LALT>
                 , <&macro_tap     &kp KP_N1 &kp KP_N5 &kp KP_N4>
                 , <&macro_release &kp LALT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -355,7 +371,7 @@
             tap-ms = <25>;
             bindings
                 = <&macro_tap     &kp SQT>
-                , <&macro_tap     &to 0>
+                , <&macro_tap     &to WEN_BASE>
                 ;
         )
 
@@ -367,10 +383,10 @@
         base_wen_layer {
 // 0: COLEMAK-DH
             bindings = <
-    &to 9   &kp W  &kp F        &kp P      &kp B           &kp J   &kp L      &kp U       &kp Y    &kp Q
-    &kp A   &kp R  &kp S        &kp T      &kp G           &kp M   &kp N      &kp E       &kp I    &kp O
-    &to 8   &to 7  &kp C        &kp D      &kp V           &kp K   &kp H      &kp SLASH   &kp X    &kp Z
-    &kp N1  &mo 6  &lt 1 SPACE  &lt 5 TAB  &kp N2          &kp N3  &lt 3 RET  &lt 2 BSPC  &mo 4    &kp N4
+    &to WEN_DL   &kp W       &kp F          &kp P    &kp B           &kp J   &kp L            &kp U             &kp Y     &kp Q
+    &kp A        &kp R       &kp S          &kp T    &kp G           &kp M   &kp N            &kp E             &kp I     &kp O
+    &to WEN_DAL  &to WEN_AL  &kp C          &kp D    &kp V           &kp K   &kp H            &kp SLASH         &kp X     &kp Z
+    &kp N1       &mo MEDIA   &lt NAV SPACE  &kp TAB  &kp N2          &kp N3  &lt WEN_SYM RET  &lt WEN_NUM BSPC  &mo FUNC  &kp N4
             >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
@@ -427,18 +443,6 @@
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
         };
 
-        mouse_layer {
-// 5: MOUSE,  NOT SUPPORTED YET
-            bindings = <
-    &none     &none     &none      &none      &none           &kp K_AGAIN  &kp K_PASTE  &kp K_COPY  &kp K_CUT  &kp K_UNDO
-    &kp LGUI  &kp LALT  &kp LCTRL  &kp LSHFT  &none           &none        &none        &none       &none      &none
-    &none     &none     &none      &none      &none           &none        &none        &none       &none      &none
-    &kp N1    &none     &none      &none      &kp N2          &kp N3       &none        &none       &none      &kp N4
-            >;
-
-            sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
-        };
-
         media_layer {
 // 6: Media
             bindings = <
@@ -454,10 +458,10 @@
         acute_wen_layer {
 // 7: Acute Layer
             bindings = <
-    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_acute_wen    &to 0                &to 0
-    &a_acute_wen  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &e_acute_wen    &i_acute_wen         &o_acute_wen
-    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &m_sqt_diaresis_wen  &to 0
-    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &to 0                &to 0
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_acute_wen  &to WEN_BASE         &to WEN_BASE
+    &a_acute_wen  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &e_acute_wen  &i_acute_wen         &o_acute_wen
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &m_sqt_diaresis_wen  &to WEN_BASE
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE         &to WEN_BASE
           >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
@@ -466,10 +470,10 @@
         dacute_wen_layer {
 // 8: Double Acute Layer
             bindings = <
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_dacute_wen  &to 0  &to 0
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &o_dacute_wen
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &m_dot_acute_wen
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &to 0
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_dacute_wen  &to WEN_BASE  &to WEN_BASE
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE   &to WEN_BASE  &o_dacute_wen
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE   &to WEN_BASE  &m_dot_acute_wen
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE   &to WEN_BASE  &to WEN_BASE
           >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
@@ -478,10 +482,10 @@
         diaresis_layer {
 // 9: Diaresis Layer
             bindings = <
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_diaresis_wen  &to 0  &m_comma_dacute_wen
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &o_diaresis_wen
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &to 0
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &to 0
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_diaresis_wen  &to WEN_BASE  &m_comma_dacute_wen
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE     &to WEN_BASE  &o_diaresis_wen
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE     &to WEN_BASE  &to WEN_BASE
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE     &to WEN_BASE  &to WEN_BASE
           >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;

--- a/config/waterfowl.keymap
+++ b/config/waterfowl.keymap
@@ -52,6 +52,22 @@
         ignore-modifiers;
       };
 
+      dqt_qmark_wen: dqt_qmark_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "DQT_QMARK_WEN";
+        #binding-cells = <0>;
+        bindings = <&kp DQT>, <&kp QMARK>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
+      sqt_fslh_wen: sqt_fslh_wen_with_shift {
+        compatible = "zmk,behavior-mod-morph";
+        label = "SQT_FSLH_WEN";
+        #binding-cells = <0>;
+        bindings = <&kp SQT>, <&kp FSLH>;
+        mods = <(MOD_RSFT|MOD_LSFT)>;
+      };
+
       o_acute_wen: o_acute_wen_with_shift {
         compatible = "zmk,behavior-mod-morph";
         label = "O_ACUTE_WITH_SHIFT";
@@ -59,7 +75,7 @@
         bindings = <&m_o_acute_wen>, <&m_cap_o_acute_wen>;
         mods = <(MOD_RSFT|MOD_LSFT)>;
       };
-      
+
       e_acute_wen: e_acute_wen_with_shift {
         compatible = "zmk,behavior-mod-morph";
         label = "E_ACUTE_WITH_SHIFT";
@@ -260,11 +276,11 @@
                 ;
         )
 
-        ZMK_MACRO(m_dot_acute_wen,
+        ZMK_MACRO(m_sqt_fslh_acute_wen,
             wait-ms = <25>;
             tap-ms = <25>;
             bindings
-                = <&macro_tap     &kp DOT>
+                = <&macro_tap     &sqt_fslh_wen>
                 , <&macro_tap     &to WEN_BASE>
                 ;
         )
@@ -366,11 +382,11 @@
                 ;
         )
 
-        ZMK_MACRO(m_sqt_diaresis_wen,
+        ZMK_MACRO(m_dot_diaresis_wen,
             wait-ms = <25>;
             tap-ms = <25>;
             bindings
-                = <&macro_tap     &kp SQT>
+                = <&macro_tap     &kp DOT>
                 , <&macro_tap     &to WEN_BASE>
                 ;
         )
@@ -383,9 +399,9 @@
         base_wen_layer {
 // 0: COLEMAK-DH
             bindings = <
-    &to WEN_DL   &kp W       &kp F          &kp P    &kp B           &kp J   &kp L        &kp U                 &kp Y     &kp Q
+    &to WEN_DAL  &kp W       &kp F          &kp P    &kp B           &kp J   &kp L        &kp U                 &kp Y     &kp Q
     &kp A        &kp R       &kp S          &kp T    &kp G           &kp M   &kp N        &kp E                 &kp I     &kp O
-    &to WEN_DAL  &to WEN_AL  &kp C          &kp D    &kp V           &kp K   &kp H        &kp SLASH             &kp X     &kp Z
+    &to WEN_DL   &to WEN_AL  &kp C          &kp D    &kp V           &kp K   &kp H        &dqt_qmark_wen        &kp X     &kp Z
     &kp N1       &mo MEDIA   &lt NAV SPACE  &kp TAB  &kp N2          &kp N3  &skq LSHFT   &lt WEN_NUM LC(BSPC)  &mo FUNC  &kp N4
             >;
 
@@ -410,9 +426,9 @@
         number_layer {
 // 2: NUM, KP_DOT would be better here instad of DOT, but num lock state interferes with KP_DOT.
             bindings = <
-    &kp LBKT   &kp N7      &kp N8  &kp N9     &kp RBKT           &none   &none      &none      &none     &none
-    &kp SEMI   &kp N4      &kp N5  &kp N6     &kp EQUAL          &none   &kp LSHFT  &kp LCTRL  &kp LALT  &kp LGUI
-    &kp GRAVE  &kp N1      &kp N2  &kp N3     &kp BSLH           &none   &none      &none      &none     &none
+    &kp LBKT   &kp N7   &kp N8  &kp N9     &kp RBKT           &none   &none      &none      &none     &none
+    &kp SEMI   &kp N4   &kp N5  &kp N6     &kp EQUAL          &none   &kp LSHFT  &kp LCTRL  &kp LALT  &kp LGUI
+    &kp GRAVE  &kp N1   &kp N2  &kp N3     &kp BSLH           &none   &none      &none      &none     &none
     &kp N1     &kp DOT  &kp N0  &kp MINUS  &kp N2             &kp N3  &none      &none      &none     &kp N4
             >;
 
@@ -434,10 +450,10 @@
         function_layer {
 // 4: FUNC
             bindings = <
-    &kp F12  &kp F7     &kp F8     &kp F9     &kp PSCRN                &none   &none       &none       &none      &none
-    &kp F11  &kp F4     &kp F5     &kp F6     &kp SLCK                 &none   &skq LSHFT  &skq LCTRL  &skq LALT  &skq LGUI
-    &kp F10  &kp F1     &kp F2     &kp F3     &kp PAUSE_BREAK          &none   &none       &none       &none      &none
-    &kp N1   &kp ESC    &kp SPACE  &kp K_APP  &kp N2                   &kp N3  &none       &none       &none      &kp N4
+    &kp F12  &kp F7   &kp F8     &kp F9     &kp PSCRN                &none   &none       &none       &none      &none
+    &kp F11  &kp F4   &kp F5     &kp F6     &kp SLCK                 &none   &skq LSHFT  &skq LCTRL  &skq LALT  &skq LGUI
+    &kp F10  &kp F1   &kp F2     &kp F3     &kp PAUSE_BREAK          &none   &none       &none       &none      &none
+    &kp N1   &kp ESC  &kp SPACE  &kp K_APP  &kp N2                   &kp N3  &none       &none       &none      &kp N4
             >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
@@ -458,10 +474,10 @@
         acute_wen_layer {
 // 7: Acute Layer
             bindings = <
-    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_acute_wen  &to WEN_BASE         &to WEN_BASE
-    &a_acute_wen  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &e_acute_wen  &i_acute_wen         &o_acute_wen
-    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &m_sqt_diaresis_wen  &to WEN_BASE
-    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE         &to WEN_BASE
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_acute_wen  &to WEN_BASE           &to WEN_BASE
+    &a_acute_wen  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &e_acute_wen  &i_acute_wen           &o_acute_wen
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &m_sqt_fslh_acute_wen  &to WEN_BASE
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE
           >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
@@ -470,9 +486,9 @@
         dacute_wen_layer {
 // 8: Double Acute Layer
             bindings = <
-    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_dacute_wen  &to WEN_BASE  &to WEN_BASE
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_dacute_wen  &to WEN_BASE  &m_comma_dacute_wen 
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE   &to WEN_BASE  &o_dacute_wen
-    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE   &to WEN_BASE  &m_dot_acute_wen
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE   &to WEN_BASE  &to WEN_BASE
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE   &to WEN_BASE  &to WEN_BASE
           >;
 
@@ -482,9 +498,9 @@
         diaresis_layer {
 // 9: Diaresis Layer
             bindings = <
-    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_diaresis_wen  &to WEN_BASE  &m_comma_dacute_wen
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &u_diaresis_wen  &to WEN_BASE  &to WEN_BASE
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE     &to WEN_BASE  &o_diaresis_wen
-    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE     &to WEN_BASE  &to WEN_BASE
+    &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE     &to WEN_BASE  &m_dot_diaresis_wen
     &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE  &to WEN_BASE           &to WEN_BASE  &to WEN_BASE  &to WEN_BASE     &to WEN_BASE  &to WEN_BASE
           >;
 

--- a/config/waterfowl.keymap
+++ b/config/waterfowl.keymap
@@ -24,6 +24,31 @@
       };
     };
 
+/* macros {
+        ZMK_MACRO(mq,
+            wait-ms = <30>;
+            tap-ms = <40>;
+            bindings = <&kp Q &to 0>;
+        )
+
+        ZMK_MACRO(my_macro,
+            wait-ms = <30>;
+            tap-ms = <40>;
+            bindings = <&kp Z &kp M &kp K>;
+        )
+    };
+
+    behaviors {
+        td0: tap_dance_0 {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_0";
+            #binding-cells = <0>;
+            tapping-term-ms = <200>;
+            bindings = <&kp N1>, <&kp N2>, <&kp N3>, <&my_macro>;
+        };
+    };
+  */  
+
     keymap {
         compatible = "zmk,keymap";
 
@@ -114,5 +139,16 @@
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
         };
 
+        accent_layer {
+// 7: Accent
+            bindings = <
+    &mq         &kp W       &kp F        &kp P        &kp B           &kp J   &kp L        &kp U        &kp Y         &kp SQT
+    &mt LGUI A  &mt LALT R  &mt LCTRL S  &mt LSHFT T  &kp G           &kp M   &mt LSHFT N  &mt LCTRL E  &mt LALT I    &mt LGUI O
+    &kp Z       &mt RALT X  &kp C        &kp D        &kp V           &kp K   &kp H        &kp COMMA    &mt RALT DOT  &kp SLASH
+    &kp N1      &lt 6 ESC   &lt 1 SPACE  &lt 5 TAB    &kp N2          &kp N3  &lt 3 RET    &lt 2 BSPC   &lt 4 DEL     &kp N4
+          >;
+
+            sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
+        };
     };
 };

--- a/config/waterfowl.keymap
+++ b/config/waterfowl.keymap
@@ -383,10 +383,10 @@
         base_wen_layer {
 // 0: COLEMAK-DH
             bindings = <
-    &to WEN_DL   &kp W       &kp F          &kp P    &kp B           &kp J   &kp L            &kp U             &kp Y     &kp Q
-    &kp A        &kp R       &kp S          &kp T    &kp G           &kp M   &kp N            &kp E             &kp I     &kp O
-    &to WEN_DAL  &to WEN_AL  &kp C          &kp D    &kp V           &kp K   &kp H            &kp SLASH         &kp X     &kp Z
-    &kp N1       &mo MEDIA   &lt NAV SPACE  &kp TAB  &kp N2          &kp N3  &lt WEN_SYM RET  &lt WEN_NUM BSPC  &mo FUNC  &kp N4
+    &to WEN_DL   &kp W       &kp F          &kp P    &kp B           &kp J   &kp L        &kp U                 &kp Y     &kp Q
+    &kp A        &kp R       &kp S          &kp T    &kp G           &kp M   &kp N        &kp E                 &kp I     &kp O
+    &to WEN_DAL  &to WEN_AL  &kp C          &kp D    &kp V           &kp K   &kp H        &kp SLASH             &kp X     &kp Z
+    &kp N1       &mo MEDIA   &lt NAV SPACE  &kp TAB  &kp N2          &kp N3  &skq LSHFT   &lt WEN_NUM LC(BSPC)  &mo FUNC  &kp N4
             >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
@@ -408,11 +408,11 @@
         };
 
         number_layer {
-// 2: NUM
+// 2: NUM, KP_DOT would be better here instad of DOT, but num lock state interferes with KP_DOT.
             bindings = <
-    &kp LBKT   &kp N7   &kp N8  &kp N9     &kp RBKT           &none   &none      &none      &none     &none
-    &kp SEMI   &kp N4   &kp N5  &kp N6     &kp EQUAL          &none   &kp LSHFT  &kp LCTRL  &kp LALT  &kp LGUI
-    &kp GRAVE  &kp N1   &kp N2  &kp N3     &kp BSLH           &none   &none      &none      &none     &none
+    &kp LBKT   &kp N7      &kp N8  &kp N9     &kp RBKT           &none   &none      &none      &none     &none
+    &kp SEMI   &kp N4      &kp N5  &kp N6     &kp EQUAL          &none   &kp LSHFT  &kp LCTRL  &kp LALT  &kp LGUI
+    &kp GRAVE  &kp N1      &kp N2  &kp N3     &kp BSLH           &none   &none      &none      &none     &none
     &kp N1     &kp DOT  &kp N0  &kp MINUS  &kp N2             &kp N3  &none      &none      &none     &kp N4
             >;
 

--- a/config/waterfowl.keymap
+++ b/config/waterfowl.keymap
@@ -297,11 +297,11 @@
                 ;
         )
 
-        ZMK_MACRO(m_slash_dacute_wen,
+        ZMK_MACRO(m_comma_dacute_wen,
             wait-ms = <25>;
             tap-ms = <25>;
             bindings
-                = <&macro_tap     &kp SLASH>
+                = <&macro_tap     &kp COMMA>
                 , <&macro_tap     &to 0>
                 ;
         )
@@ -369,7 +369,7 @@
             bindings = <
     &to 9   &kp W  &kp F        &kp P      &kp B           &kp J   &kp L      &kp U       &kp Y    &kp Q
     &kp A   &kp R  &kp S        &kp T      &kp G           &kp M   &kp N      &kp E       &kp I    &kp O
-    &to 8   &to 7  &kp C        &kp D      &kp V           &kp K   &kp H      &kp COMMA   &kp X    &kp Z
+    &to 8   &to 7  &kp C        &kp D      &kp V           &kp K   &kp H      &kp SLASH   &kp X    &kp Z
     &kp N1  &mo 6  &lt 1 SPACE  &lt 5 TAB  &kp N2          &kp N3  &lt 3 RET  &lt 2 BSPC  &mo 4    &kp N4
             >;
 
@@ -454,10 +454,10 @@
         acute_wen_layer {
 // 7: Acute Layer
             bindings = <
-    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_acute_wen    &to 0             &to 0
-    &a_acute_wen  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &e_acute_wen    &i_acute_wen      &o_acute_wen
-    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &m_dot_acute_wen  &to 0
-    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &to 0             &to 0
+    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_acute_wen    &to 0                &to 0
+    &a_acute_wen  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &e_acute_wen    &i_acute_wen         &o_acute_wen
+    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &m_sqt_diaresis_wen  &to 0
+    &to 0         &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0           &to 0                &to 0
           >;
 
             sensor-bindings = <&inc_dec_kp PAGE_UP PAGE_DOWN &inc_dec_kp TAB LS(TAB)>;
@@ -468,7 +468,7 @@
             bindings = <
     &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_dacute_wen  &to 0  &to 0
     &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &o_dacute_wen
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &m_slash_dacute_wen
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &m_dot_acute_wen
     &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0          &to 0  &to 0
           >;
 
@@ -478,7 +478,7 @@
         diaresis_layer {
 // 9: Diaresis Layer
             bindings = <
-    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_diaresis_wen  &to 0  &m_sqt_diaresis_wen
+    &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &u_diaresis_wen  &to 0  &m_comma_dacute_wen
     &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &o_diaresis_wen
     &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &to 0
     &to 0  &to 0  &to 0  &to 0  &to 0           &to 0  &to 0  &to 0            &to 0  &to 0


### PR DESCRIPTION
The double acute characters can only be typed when the host layout is set to hungarian. The US International layout does not have those. 

Sending unicode alt sequences using a macro is not optimal because the execution of the macro takes a lot if time. The following macro takes 0.34 s to execute, which can cause problems if you roll onto the next key press before the macro is done.

```
        ZMK_MACRO(a_acute,
            wait-ms = <30>;
            tap-ms = <40>;
            bindings =
	         <&macro_press   &kp LALT>
               , <&macro_tap     &kp KP_N0 &kp KP_N2 &kp KP_N2 &kp KP_N5>
               , <&macro_release &kp LALT>;)
```




 